### PR TITLE
Implement rotor double step handling and add tests

### DIFF
--- a/EnigmaMachine.Domain.Tests/EnigmaMachine.Domain.Tests.csproj
+++ b/EnigmaMachine.Domain.Tests/EnigmaMachine.Domain.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EnigmaMachine.Domain\EnigmaMachine.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/EnigmaMachine.Domain.Tests/RotorSteppingTests.cs
+++ b/EnigmaMachine.Domain.Tests/RotorSteppingTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using EnigmaMachine.Domain.Entities;
+using EnigmaMachine.Domain.Interfaces;
+using EnigmaMachine.Domain.ValueObjects;
+using Xunit;
+
+namespace EnigmaMachine.Domain.Tests
+{
+    public class RotorSteppingTests
+    {
+        [Fact]
+        public void DoubleStepOccursAroundNotchTransitions()
+        {
+            // Arrange: fast rotor at notch, middle one step before its notch
+            var fast = new Rotor(new RotorPosition(25));
+            var middle = new Rotor(new RotorPosition(24));
+            var left = new Rotor(new RotorPosition(0));
+            var machine = new EnigmaMachine(new List<IRotor> { fast, middle, left }, new Plugboard(), new Reflector());
+
+            // Act - first key press
+            machine.ProcessLetter(new Letter('A'));
+
+            // Assert intermediate positions
+            Assert.Equal(26, fast.Position);
+            Assert.Equal(25, middle.Position);
+            Assert.Equal(0, left.Position);
+
+            // Act - second key press
+            machine.ProcessLetter(new Letter('A'));
+
+            // Assert - middle rotor stepped twice and left rotor stepped once
+            Assert.Equal(27, fast.Position);
+            Assert.Equal(26, middle.Position);
+            Assert.Equal(1, left.Position);
+        }
+    }
+}

--- a/EnigmaMachine.Domain/Entities/EnigmaMachine.cs
+++ b/EnigmaMachine.Domain/Entities/EnigmaMachine.cs
@@ -74,18 +74,30 @@ namespace EnigmaMachine.Domain.Entities
                 return;
             }
 
-            _rotors[0].Rotate();
+            // Check the notch positions before any rotation occurs.
+            var fastAtNotchBefore = _rotors[0].IsAtNotch;
+            var middleAtNotchBefore = _rotors.Count > 1 && _rotors[1].IsAtNotch;
 
-            for (int i = 0; i < _rotors.Count - 1; i++)
+            // The fast (right-most) rotor always rotates.
+            _rotors[0].Rotate();
+            _ = _rotors[0].IsAtNotch; // Check notch after rotation
+
+            // The middle rotor rotates if the fast rotor was at its notch or if it
+            // is itself at the notch (the double-stepping mechanism).
+            if (_rotors.Count > 1 && (fastAtNotchBefore || middleAtNotchBefore))
             {
-                if (_rotors[i].Position % 26 == 0)
-                {
-                    _rotors[i + 1].Rotate();
-                }
-                else
-                {
-                    break;
-                }
+                _rotors[1].Rotate();
+            }
+            if (_rotors.Count > 1)
+            {
+                _ = _rotors[1].IsAtNotch; // Check notch after rotation
+            }
+
+            // The left-most rotor rotates only when the middle rotor was at its notch
+            // before any rotation took place.
+            if (_rotors.Count > 2 && middleAtNotchBefore)
+            {
+                _rotors[2].Rotate();
             }
         }
 

--- a/EnigmaMachine.Domain/Entities/Rotor.cs
+++ b/EnigmaMachine.Domain/Entities/Rotor.cs
@@ -26,6 +26,9 @@ namespace EnigmaMachine.Domain.Entities
         public int Position => _position.Position;
 
         /// <inheritdoc />
+        public bool IsAtNotch => (_position.Position + 1) % 26 == 0;
+
+        /// <inheritdoc />
         public void Rotate()
         {
             _position.Advance();

--- a/EnigmaMachine.Domain/Interfaces/IRotor.cs
+++ b/EnigmaMachine.Domain/Interfaces/IRotor.cs
@@ -14,6 +14,13 @@ namespace EnigmaMachine.Domain.Interfaces
         int Position { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the rotor is currently positioned at
+        /// its notch. When at the notch, the rotor triggers the rotation of the
+        /// rotor to its left on the next key press.
+        /// </summary>
+        bool IsAtNotch { get; }
+
+        /// <summary>
         /// Rotates the rotor to the next position.
         /// </summary>
         void Rotate();

--- a/EnigmaMachine.sln
+++ b/EnigmaMachine.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.0.31913.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Domain", "EnigmaMachine.Domain\EnigmaMachine.Domain.csproj", "{D1A5C5B2-5D5B-4D3B-8A3D-5D5B5E5B5E5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Domain.Tests", "EnigmaMachine.Domain.Tests\\EnigmaMachine.Domain.Tests.csproj", "{60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -14,5 +16,9 @@ Global
         {D1A5C5B2-5D5B-4D3B-8A3D-5D5B5E5B5E5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {D1A5C5B2-5D5B-4D3B-8A3D-5D5B5E5B5E5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {D1A5C5B2-5D5B-4D3B-8A3D-5D5B5E5B5E5B}.Release|Any CPU.Build.0 = Release|Any CPU
+        {60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- Track rotor notch positions and expose `IsAtNotch` on rotors
- Update `StepRotors` to account for notch checks and proper double-stepping
- Add tests exercising notch transition double-stepping

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2b7c1080832fa8438f63f8fbc7db