### PR TITLE
Validate plugboard connections and enforce pair limit

### DIFF
--- a/EnigmaMachine.Domain.Tests/PlugboardTests.cs
+++ b/EnigmaMachine.Domain.Tests/PlugboardTests.cs
@@ -1,0 +1,33 @@
+using System;
+using EnigmaMachine.Domain.Entities;
+using EnigmaMachine.Domain.ValueObjects;
+using Xunit;
+
+namespace EnigmaMachine.Domain.Tests;
+
+public class PlugboardTests
+{
+    [Fact]
+    public void ConnectingLetterTwiceThrows()
+    {
+        var plugboard = new Plugboard();
+        plugboard.Connect(new PlugboardPair('A', 'B'));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => plugboard.Connect(new PlugboardPair('A', 'C')));
+        Assert.Contains("already connected", ex.Message);
+    }
+
+    [Fact]
+    public void ExceedingMaximumPairsThrows()
+    {
+        var plugboard = new Plugboard();
+        var pairs = new[] { "AB", "CD", "EF", "GH", "IJ", "KL", "MN", "OP", "QR", "ST" };
+        foreach (var pair in pairs)
+        {
+            plugboard.Connect(new PlugboardPair(pair[0], pair[1]));
+        }
+
+        Assert.Throws<InvalidOperationException>(() => plugboard.Connect(new PlugboardPair('U', 'V')));
+    }
+}
+

--- a/EnigmaMachine.Domain/Entities/Plugboard.cs
+++ b/EnigmaMachine.Domain/Entities/Plugboard.cs
@@ -10,6 +10,7 @@ namespace EnigmaMachine.Domain.Entities
     /// </summary>
     public class Plugboard : IPlugboard
     {
+        private const int MaxPairs = 10;
         private readonly Dictionary<char, char> _connections;
 
         /// <summary>
@@ -25,6 +26,15 @@ namespace EnigmaMachine.Domain.Entities
         {
             if (letter1 == letter2)
                 throw new ArgumentException("Cannot connect a letter to itself.");
+
+            if (_connections.ContainsKey(letter1))
+                throw new InvalidOperationException($"Letter '{letter1}' is already connected to '{_connections[letter1]}'.");
+
+            if (_connections.ContainsKey(letter2))
+                throw new InvalidOperationException($"Letter '{letter2}' is already connected to '{_connections[letter2]}'.");
+
+            if (_connections.Count >= MaxPairs * 2)
+                throw new InvalidOperationException($"Plugboard can have at most {MaxPairs} pairs.");
 
             _connections[letter1] = letter2;
             _connections[letter2] = letter1;


### PR DESCRIPTION
## Summary
- prevent duplicate plugboard connections by throwing an exception when a letter is already paired
- limit the plugboard to at most ten pairs to mirror real Enigma machine restrictions
- add unit tests covering duplicate connections and maximum pair enforcement

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3b5d95fc832fa2fef849b2367859