### PR TITLE
Normalize Plugboard pairs and adopt value-based Letter

### DIFF
--- a/EnigmaMachine.Domain.Tests/LetterTests.cs
+++ b/EnigmaMachine.Domain.Tests/LetterTests.cs
@@ -1,0 +1,26 @@
+using EnigmaMachine.Domain.ValueObjects;
+using Xunit;
+
+namespace EnigmaMachine.Domain.Tests
+{
+    public class LetterTests
+    {
+        [Fact]
+        public void Letters_WithSameCharacter_AreEqual()
+        {
+            var a1 = new Letter('A');
+            var a2 = new Letter('a');
+
+            Assert.Equal(a1, a2);
+        }
+
+        [Fact]
+        public void Letters_WithDifferentCharacters_AreNotEqual()
+        {
+            var a = new Letter('A');
+            var b = new Letter('B');
+
+            Assert.NotEqual(a, b);
+        }
+    }
+}

--- a/EnigmaMachine.Domain.Tests/PlugboardPairTests.cs
+++ b/EnigmaMachine.Domain.Tests/PlugboardPairTests.cs
@@ -1,0 +1,18 @@
+using EnigmaMachine.Domain.ValueObjects;
+using Xunit;
+
+namespace EnigmaMachine.Domain.Tests
+{
+    public class PlugboardPairTests
+    {
+        [Fact]
+        public void Equality_IsOrderInsensitive()
+        {
+            var pair1 = new PlugboardPair('A', 'B');
+            var pair2 = new PlugboardPair('B', 'A');
+
+            Assert.Equal(pair1, pair2);
+            Assert.Equal(pair1.GetHashCode(), pair2.GetHashCode());
+        }
+    }
+}

--- a/EnigmaMachine.Domain/Entities/EnigmaMachine.cs
+++ b/EnigmaMachine.Domain/Entities/EnigmaMachine.cs
@@ -42,11 +42,6 @@ namespace EnigmaMachine.Domain.Entities
         /// <returns>The resulting letter after processing.</returns>
         public Letter ProcessLetter(Letter input)
         {
-            if (input == null)
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
-
             // Step rotors before processing (Enigma stepping occurs prior to encoding)
             StepRotors();
 

--- a/EnigmaMachine.Domain/ValueObjects/Letter.cs
+++ b/EnigmaMachine.Domain/ValueObjects/Letter.cs
@@ -18,7 +18,7 @@ namespace EnigmaMachine.Domain.ValueObjects
         /// </summary>
         /// <param name="character">The character representing the letter.</param>
         /// <exception cref="ArgumentException">Thrown when the character is not a valid letter.</exception>
-        public Letter(char character) : this()
+        public Letter(char character)
         {
             if (!char.IsLetter(character))
             {

--- a/EnigmaMachine.Domain/ValueObjects/Letter.cs
+++ b/EnigmaMachine.Domain/ValueObjects/Letter.cs
@@ -14,7 +14,7 @@ namespace EnigmaMachine.Domain.ValueObjects
         public char Character { get; init; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Letter"/> struct.
+        /// Initializes a new instance of the <see cref="Letter"/> record struct.
         /// </summary>
         /// <param name="character">The character representing the letter.</param>
         /// <exception cref="ArgumentException">Thrown when the character is not a valid letter.</exception>

--- a/EnigmaMachine.Domain/ValueObjects/Letter.cs
+++ b/EnigmaMachine.Domain/ValueObjects/Letter.cs
@@ -6,19 +6,19 @@ namespace EnigmaMachine.Domain.ValueObjects
     /// <summary>
     /// Represents a single letter in the encryption process.
     /// </summary>
-    public class Letter
+    public readonly record struct Letter
     {
         /// <summary>
         /// Gets the character representing the letter.
         /// </summary>
-        public char Character { get; }
+        public char Character { get; init; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Letter"/> class.
+        /// Initializes a new instance of the <see cref="Letter"/> struct.
         /// </summary>
         /// <param name="character">The character representing the letter.</param>
         /// <exception cref="ArgumentException">Thrown when the character is not a valid letter.</exception>
-        public Letter(char character)
+        public Letter(char character) : this()
         {
             if (!char.IsLetter(character))
             {
@@ -36,7 +36,5 @@ namespace EnigmaMachine.Domain.ValueObjects
         {
             return Character.ToString();
         }
-
-        // Additional methods and overrides (e.g., Equals, GetHashCode) can be added as needed.
     }
 }

--- a/EnigmaMachine.Domain/ValueObjects/PlugboardPair.cs
+++ b/EnigmaMachine.Domain/ValueObjects/PlugboardPair.cs
@@ -35,6 +35,12 @@ namespace EnigmaMachine.Domain.ValueObjects
             if (firstLetter == secondLetter)
                 throw new ArgumentException("Plugboard cannot connect a letter to itself.");
 
+            // Normalize ordering so that (A,B) is considered equal to (B,A)
+            if (firstLetter > secondLetter)
+            {
+                (firstLetter, secondLetter) = (secondLetter, firstLetter);
+            }
+
             FirstLetter = firstLetter;
             SecondLetter = secondLetter;
         }


### PR DESCRIPTION
## Summary
- convert `Letter` to a readonly record struct for value equality
- normalize `PlugboardPair` letters so AB equals BA
- add tests covering `PlugboardPair` symmetry and `Letter` equality

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08142a028832f960792d44100ed11