### PR TITLE
Add application layer with MediatR-based text processing

### DIFF
--- a/EnigmaMachine.Application/Commands/ProcessTextCommand.cs
+++ b/EnigmaMachine.Application/Commands/ProcessTextCommand.cs
@@ -1,0 +1,15 @@
+using MediatR;
+using EnigmaMachine.Application.Dtos;
+using EnigmaMachine.Domain.ValueObjects;
+
+namespace EnigmaMachine.Application.Commands;
+
+public sealed record MachineConfiguration(
+    RotorType[] Rotors,
+    string RingSettings,
+    string InitialPositions,
+    string[] PlugboardPairs);
+
+public sealed record ProcessTextCommand(
+    string InputText,
+    MachineConfiguration Configuration) : IRequest<ProcessTextResult>;

--- a/EnigmaMachine.Application/Commands/ProcessTextCommand.cs
+++ b/EnigmaMachine.Application/Commands/ProcessTextCommand.cs
@@ -8,7 +8,7 @@ public sealed record MachineConfiguration(
     RotorType[] Rotors,
     string RingSettings,
     string InitialPositions,
-    string[] PlugboardPairs);
+    string[]? PlugboardPairs);
 
 public sealed record ProcessTextCommand(
     string InputText,

--- a/EnigmaMachine.Application/Commands/ProcessTextCommand.cs
+++ b/EnigmaMachine.Application/Commands/ProcessTextCommand.cs
@@ -11,5 +11,5 @@ public sealed record MachineConfiguration(
     string[]? PlugboardPairs);
 
 public sealed record ProcessTextCommand(
-    string InputText,
+    string? InputText,
     MachineConfiguration Configuration) : IRequest<ProcessTextResult>;

--- a/EnigmaMachine.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/EnigmaMachine.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EnigmaMachine.Application.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(ServiceCollectionExtensions).Assembly));
+        return services;
+    }
+}

--- a/EnigmaMachine.Application/Dtos/MachineStateDto.cs
+++ b/EnigmaMachine.Application/Dtos/MachineStateDto.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace EnigmaMachine.Application.Dtos;
+
+public sealed record MachineStateDto(
+    char Input,
+    char Output,
+    IReadOnlyList<char> RotorPositions);

--- a/EnigmaMachine.Application/Dtos/ProcessTextResult.cs
+++ b/EnigmaMachine.Application/Dtos/ProcessTextResult.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+namespace EnigmaMachine.Application.Dtos;
+
+public sealed record ProcessTextResult(
+    string CipherText,
+    IReadOnlyList<MachineStateDto> Steps);

--- a/EnigmaMachine.Application/EnigmaMachine.Application.csproj
+++ b/EnigmaMachine.Application/EnigmaMachine.Application.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EnigmaMachine.Domain\EnigmaMachine.Domain.csproj" />
+    <PackageReference Include="MediatR" Version="12.1.1" />
+  </ItemGroup>
+</Project>

--- a/EnigmaMachine.Application/Handlers/ProcessTextHandler.cs
+++ b/EnigmaMachine.Application/Handlers/ProcessTextHandler.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using EnigmaMachine.Application.Commands;
+using EnigmaMachine.Application.Dtos;
+using EnigmaMachine.Domain.Entities;
+using EnigmaMachine.Domain.Factories;
+using EnigmaMachine.Domain.Interfaces;
+using EnigmaMachine.Domain.ValueObjects;
+
+namespace EnigmaMachine.Application.Handlers;
+
+public sealed class ProcessTextHandler : IRequestHandler<ProcessTextCommand, ProcessTextResult>
+{
+    public Task<ProcessTextResult> Handle(ProcessTextCommand request, CancellationToken cancellationToken)
+    {
+        var cfg = request.Configuration;
+
+        var plugboard = new Plugboard();
+        if (cfg.PlugboardPairs != null)
+        {
+            foreach (var pair in cfg.PlugboardPairs)
+            {
+                if (pair?.Length >= 2)
+                {
+                    plugboard.Connect(new PlugboardPair(pair[0], pair[1]));
+                }
+            }
+        }
+
+        var reflector = new ReflectorB();
+        var machine = EnigmaMachineFactory.CreateEnigmaILeftToRight(
+            cfg.Rotors,
+            cfg.RingSettings.ToUpperInvariant().ToCharArray(),
+            cfg.InitialPositions.ToUpperInvariant().ToCharArray(),
+            plugboard,
+            reflector);
+
+        var diag = (IDiagnosticEnigmaMachine)machine;
+        var transformer = new DefaultTextTransformer();
+        var encoded = transformer.Encode(request.InputText ?? string.Empty);
+
+        var sb = new StringBuilder();
+        var states = new List<MachineStateDto>();
+
+        foreach (var ch in encoded)
+        {
+            if (!char.IsLetter(ch))
+            {
+                sb.Append(ch);
+                continue;
+            }
+
+            var inputLetter = new Letter(ch);
+            var output = machine.ProcessLetter(inputLetter).Character;
+            sb.Append(output);
+
+            var positions = diag.RotorPositionsView.Select(rp => rp.Letter).ToArray();
+            states.Add(new MachineStateDto(ch, output, positions));
+        }
+
+        var result = new ProcessTextResult(sb.ToString(), states);
+        return Task.FromResult(result);
+    }
+}

--- a/EnigmaMachine.sln
+++ b/EnigmaMachine.sln
@@ -4,7 +4,9 @@ VisualStudioVersion = 17.0.31913.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Domain", "EnigmaMachine.Domain\EnigmaMachine.Domain.csproj", "{D1A5C5B2-5D5B-4D3B-8A3D-5D5B5E5B5E5B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Domain.Tests", "EnigmaMachine.Domain.Tests\\EnigmaMachine.Domain.Tests.csproj", "{60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Domain.Tests", "EnigmaMachine.Domain.Tests\EnigmaMachine.Domain.Tests.csproj", "{60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Application", "EnigmaMachine.Application\EnigmaMachine.Application.csproj", "{D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}"
 EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,5 +22,9 @@ Global
         {60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {60CD04B3-D664-47C8-9E8B-D91EEA9DAAA7}.Release|Any CPU.Build.0 = Release|Any CPU
+        {D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- Add EnigmaMachine.Application project referencing Domain and MediatR
- Implement ProcessTextCommand/Handler and supporting DTOs for letter-by-letter machine processing
- Provide DI extension to register MediatR handlers

## Testing
- ⚠️ `dotnet test` *(missing dotnet CLI in container)*


------
https://chatgpt.com/codex/tasks/task_e_68c13748ebac832f98cb99dd00b57ec8