### PR TITLE
Add API project with Enigma processing endpoint

### DIFF
--- a/EnigmaMachine.Api/EnigmaMachine.Api.csproj
+++ b/EnigmaMachine.Api/EnigmaMachine.Api.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\EnigmaMachine.Application\\EnigmaMachine.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/EnigmaMachine.Api/Program.cs
+++ b/EnigmaMachine.Api/Program.cs
@@ -1,0 +1,29 @@
+using EnigmaMachine.Application.Commands;
+using EnigmaMachine.Application.DependencyInjection;
+using EnigmaMachine.Domain.Entities;
+using EnigmaMachine.Domain.Factories;
+using EnigmaMachine.Domain.Interfaces;
+using EnigmaMachine.Domain.ValueObjects;
+using MediatR;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Application services
+builder.Services.AddApplication();
+
+// Domain factories
+builder.Services.AddTransient<Func<IPlugboard>>(_ => () => new Plugboard());
+builder.Services.AddTransient<Func<IReflector>>(_ => () => new ReflectorB());
+builder.Services.AddTransient<Func<RotorType[], char[], char[], IPlugboard, IReflector, IEnigmaMachine>>(
+    _ => (rotors, ringSettings, initialPositions, plugboard, reflector) =>
+        EnigmaMachineFactory.CreateEnigmaILeftToRight(rotors, ringSettings, initialPositions, plugboard, reflector));
+
+var app = builder.Build();
+
+app.MapPost("/api/enigma/process", async (ProcessTextCommand command, IMediator mediator) =>
+{
+    var result = await mediator.Send(command);
+    return Results.Ok(result);
+});
+
+app.Run();

--- a/EnigmaMachine.Application/Handlers/ProcessTextHandler.cs
+++ b/EnigmaMachine.Application/Handlers/ProcessTextHandler.cs
@@ -15,11 +15,25 @@ namespace EnigmaMachine.Application.Handlers;
 
 public sealed class ProcessTextHandler : IRequestHandler<ProcessTextCommand, ProcessTextResult>
 {
+    private readonly Func<IPlugboard> _plugboardFactory;
+    private readonly Func<IReflector> _reflectorFactory;
+    private readonly Func<RotorType[], char[], char[], IPlugboard, IReflector, IEnigmaMachine> _machineFactory;
+
+    public ProcessTextHandler(
+        Func<IPlugboard> plugboardFactory,
+        Func<IReflector> reflectorFactory,
+        Func<RotorType[], char[], char[], IPlugboard, IReflector, IEnigmaMachine> machineFactory)
+    {
+        _plugboardFactory = plugboardFactory;
+        _reflectorFactory = reflectorFactory;
+        _machineFactory = machineFactory;
+    }
+
     public Task<ProcessTextResult> Handle(ProcessTextCommand request, CancellationToken cancellationToken)
     {
         var cfg = request.Configuration;
 
-        var plugboard = new Plugboard();
+        var plugboard = _plugboardFactory();
         if (cfg.PlugboardPairs != null)
         {
             foreach (var pair in cfg.PlugboardPairs)
@@ -31,8 +45,8 @@ public sealed class ProcessTextHandler : IRequestHandler<ProcessTextCommand, Pro
             }
         }
 
-        var reflector = new ReflectorB();
-        var machine = EnigmaMachineFactory.CreateEnigmaILeftToRight(
+        var reflector = _reflectorFactory();
+        var machine = _machineFactory(
             cfg.Rotors,
             cfg.RingSettings.ToUpperInvariant().ToCharArray(),
             cfg.InitialPositions.ToUpperInvariant().ToCharArray(),

--- a/EnigmaMachine.sln
+++ b/EnigmaMachine.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Domain.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Application", "EnigmaMachine.Application\EnigmaMachine.Application.csproj", "{D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnigmaMachine.Api", "EnigmaMachine.Api\EnigmaMachine.Api.csproj", "{964A1FE4-97C5-4071-91AA-4287A7658FCD}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -26,5 +28,9 @@ Global
         {D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {D9FB7E2D-AEA5-410A-95CD-73FAEA307F87}.Release|Any CPU.Build.0 = Release|Any CPU
+        {964A1FE4-97C5-4071-91AA-4287A7658FCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {964A1FE4-97C5-4071-91AA-4287A7658FCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {964A1FE4-97C5-4071-91AA-4287A7658FCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {964A1FE4-97C5-4071-91AA-4287A7658FCD}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- create EnigmaMachine.Api project referencing Application layer
- wire up dependency injection for application and domain factories
- expose POST /api/enigma/process endpoint using MediatR

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13991ec68832f820f21370a18b04a