### PR TITLE
Add plugboard state to machine diagnostics

### DIFF
--- a/EnigmaMachine.Application/Dtos/MachineStateDto.cs
+++ b/EnigmaMachine.Application/Dtos/MachineStateDto.cs
@@ -5,4 +5,5 @@ namespace EnigmaMachine.Application.Dtos;
 public sealed record MachineStateDto(
     char Input,
     char Output,
-    IReadOnlyList<char> RotorPositions);
+    IReadOnlyList<char> RotorPositions,
+    IReadOnlyList<PlugboardPairDto> Plugboard);

--- a/EnigmaMachine.Application/Dtos/PlugboardPairDto.cs
+++ b/EnigmaMachine.Application/Dtos/PlugboardPairDto.cs
@@ -1,0 +1,6 @@
+namespace EnigmaMachine.Application.Dtos;
+
+/// <summary>
+/// Data transfer object representing a pair of letters connected on the plugboard.
+/// </summary>
+public sealed record PlugboardPairDto(char First, char Second);

--- a/EnigmaMachine.Application/Handlers/ProcessTextHandler.cs
+++ b/EnigmaMachine.Application/Handlers/ProcessTextHandler.cs
@@ -73,7 +73,11 @@ public sealed class ProcessTextHandler : IRequestHandler<ProcessTextCommand, Pro
             sb.Append(output);
 
             var positions = diag.RotorPositionsView.Select(rp => rp.Letter).ToArray();
-            states.Add(new MachineStateDto(ch, output, positions));
+            var plugs = plugboard
+                .GetConnections()
+                .Select(p => new PlugboardPairDto(p.FirstLetter, p.SecondLetter))
+                .ToArray();
+            states.Add(new MachineStateDto(ch, output, positions, plugs));
         }
 
         var result = new ProcessTextResult(sb.ToString(), states);


### PR DESCRIPTION
## Summary
- expose plugboard connections via a new `PlugboardPairDto`
- extend `MachineStateDto` with plugboard data
- capture plugboard state for each processed character in `ProcessTextHandler`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c145a9def8832fbef35314405aac5d